### PR TITLE
Using an iframe for the Chrome extension instead of a redirect.

### DIFF
--- a/extra/chrome-extension/README.md
+++ b/extra/chrome-extension/README.md
@@ -1,0 +1,10 @@
+# antoligy/about-blank #
+
+A Google Chrome extension to use [about-blank](https://ax.gy/about-blank) as the new tab page.
+
+As about:blank utilises an offline-first caching pattern with service-workers, this is safe and
+will work offline.
+
+### WARNING ###
+This is very much a work in progress, I will add more thorough documentation
+on building and testing this prior to publishing on the Chrome app store.

--- a/extra/chrome-extension/src/index.html
+++ b/extra/chrome-extension/src/index.html
@@ -1,3 +1,16 @@
 <!DOCTYPE html>
 <meta charset=utf-8>
-<script type="text/javascript" src="index.js"></script>
+<title>about:blank</title>
+<iframe src="https://ax.gy/about-blank" style="
+  position: fixed;
+  top:      0;
+  bottom:   0;
+  left:     0;
+  right:    0;
+  height:   100vh;
+  width:    100vw;
+  border:   none;
+  z-index:  9999;
+" seamless>
+    <script type="text/javascript" src="index.js"></script>
+</iframe>

--- a/extra/chrome-extension/src/manifest.json
+++ b/extra/chrome-extension/src/manifest.json
@@ -7,4 +7,3 @@
     "newtab": "index.html"
   }
 }
-


### PR DESCRIPTION
This is notably faster, and benchmarking I'm now getting a new tab page much quicker than with other extensions.  Not sure why!

Annoyingly, I couldn't get this to work with a webview, as despite being far more secure + quicker they're only available to Chrome apps.